### PR TITLE
Decoding performance optimization

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,3 +23,4 @@ ratings:
   - "**.rb"
 exclude_paths:
 - test/
+- benchmark/

--- a/base62.js
+++ b/base62.js
@@ -37,10 +37,15 @@ module.exports = (function (Base62) {
     };
 
     var customCharsetDecode = function customCharsetDecode (base62String) {
-        var val = 0, base62Chars = base62String.split("").reverse();
-        base62Chars.forEach(function(character, index){
-            val += Base62.characterSet.indexOf(character) * Math.pow(62, index);
-        });
+        var val = 0,
+            i = 0,
+            length = base62String.length,
+            characterSet = Base62.characterSet;
+
+        for (; i < length; i++) {
+            val += characterSet.indexOf(base62String[i]) * Math.pow(62, length - i - 1);
+        }
+
         return val;
     };
 

--- a/base62.js
+++ b/base62.js
@@ -1,4 +1,6 @@
 module.exports = (function (Base62) {
+    "use strict";
+
     var DEFAULT_CHARACTER_SET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
     Base62.encode = function(integer){
@@ -11,7 +13,30 @@ module.exports = (function (Base62) {
         return s;
     };
 
-    Base62.decode = function(base62String){
+    var defaultCharsetDecode = function defaultCharsetDecode (base62String) {
+        var value = 0,
+            i = 0,
+            length = base62String.length,
+            charValue;
+
+        for (; i < length; i++) {
+            charValue = base62String.charCodeAt(i);
+
+            if (charValue < 58) {
+                charValue = charValue - 48;
+            } else if (charValue < 91) {
+                charValue = charValue - 29;
+            } else {
+                charValue = charValue - 87;
+            }
+
+            value += charValue * Math.pow(62, length - i - 1);
+        }
+
+        return value;
+    };
+
+    var customCharsetDecode = function customCharsetDecode (base62String) {
         var val = 0, base62Chars = base62String.split("").reverse();
         base62Chars.forEach(function(character, index){
             val += Base62.characterSet.indexOf(character) * Math.pow(62, index);
@@ -19,18 +44,26 @@ module.exports = (function (Base62) {
         return val;
     };
 
+    var decodeImplementation = null;
+
+    Base62.decode = function(base62String){
+        return decodeImplementation(base62String);
+    };
+
     Base62.setCharacterSet = function(chars) {
         var arrayOfChars = chars.split(""), uniqueCharacters = [];
 
-        if(arrayOfChars.length != 62) throw Error("You must supply 62 characters");
+        if(arrayOfChars.length !== 62) throw Error("You must supply 62 characters");
 
         arrayOfChars.forEach(function(char){
             if(!~uniqueCharacters.indexOf(char)) uniqueCharacters.push(char);
         });
 
-        if(uniqueCharacters.length != 62) throw Error("You must use unique characters.");
+        if(uniqueCharacters.length !== 62) throw Error("You must use unique characters.");
 
         Base62.characterSet = arrayOfChars;
+
+        decodeImplementation = chars === DEFAULT_CHARACTER_SET ? defaultCharsetDecode : customCharsetDecode;
     };
 
     Base62.setCharacterSet(DEFAULT_CHARACTER_SET);

--- a/benchmark/benchmarks.js
+++ b/benchmark/benchmarks.js
@@ -48,6 +48,7 @@ for (intResult = 0, i = 0; i < 1000000; i++) {
 }
 
 deltaTime = performanceNow() - now;
+
 console.log('|', 'decoding with custom charset (1000000x)', '|', intResult === 823118800000000 ? 'correct' : 'incorrect', '|', deltaTime.toFixed(2), 'ms', '|');
 
 //encode with custom charset

--- a/benchmark/benchmarks.js
+++ b/benchmark/benchmarks.js
@@ -1,0 +1,63 @@
+"use strict";
+
+var base62 = require('../'),
+    now = 0,
+    deltaTime = 0,
+    i = 0,
+    intResult = 0,
+    strResult = 0;
+
+function performanceNow(){
+    var t = process.hrtime();
+
+    return t[0] * 1000 + t[1] / 1000000;
+}
+
+//decode with default charset
+
+now = performanceNow();
+
+for (intResult = 0, i = 0; i < 1000000; i++) {
+    intResult += base62.decode('00thing');
+}
+
+deltaTime = performanceNow() - now;
+
+console.log('|', 'decoding with default charset (1000000x)', '|', intResult === 432635954000000 ? 'correct' : 'incorrect', '|', deltaTime.toFixed(2), 'ms', '|');
+
+//encode with default charset
+
+now = performanceNow();
+
+for (strResult = '', i = 0; i < 1000000; i++) {
+    strResult = base62.encode(i);
+}
+
+deltaTime = performanceNow() - now;
+
+console.log('|', 'encoding with default charset (1000000x)', '|', strResult === '4c91' ? 'correct' : 'incorrect', '|', deltaTime.toFixed(2), 'ms', '|');
+
+//decode with custom charset
+
+base62.setCharacterSet('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz');
+
+now = performanceNow();
+
+for (intResult = 0, i = 0; i < 1000000; i++) {
+    intResult += base62.decode('00thing');
+}
+
+deltaTime = performanceNow() - now;
+console.log('|', 'decoding with custom charset (1000000x)', '|', intResult === 823118800000000 ? 'correct' : 'incorrect', '|', deltaTime.toFixed(2), 'ms', '|');
+
+//encode with custom charset
+
+now = performanceNow();
+
+for (strResult = '', i = 0; i < 1000000; i++) {
+    strResult = base62.encode(i);
+}
+
+deltaTime = performanceNow() - now;
+
+console.log('|', 'encoding with custom charset (1000000x)', '|', strResult === '4C91' ? 'correct' : 'incorrect', '|', deltaTime.toFixed(2), 'ms', '|');

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "node": "*"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "benchmark": "node benchmark/benchmarks.js"
   },
   "devDependencies": {
     "mocha": "~3.4.1"

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@ var Base62 = require('../base62');
 
 describe("encode", function() {
     it("should encode a number to a Base62 string", function() {
+        assert.equal(Base62.encode(0), '0');
         assert.equal(Base62.encode(999), 'g7');
         assert.equal(Base62.encode(65), '13');
         //test big numbers
@@ -14,8 +15,11 @@ describe("encode", function() {
 
 describe("decode", function() {
     it("should decode a number from a Base62 string", function() {
+        assert.equal(Base62.decode('0'), 0);
         assert.equal(Base62.decode('g7'), 999);
         assert.equal(Base62.decode('13'), 65);
+        //zero padded strings
+        assert.equal(Base62.decode('0013'), 65);
         //test big numbers
         assert.equal(Base62.decode("2Q3rKTOF"), 10000000000001);
         assert.equal(Base62.decode("2Q3rKTOH"), 10000000000003);


### PR DESCRIPTION
The aim of this PR is to optimize the performance of the decode() method. The setCharacterSet method is now swapping the decode method implementation with an optimized one when the default charset is given. The improvement comes from the lack of array search (no `indexOf`) in this specific implementation. At first I intended to swap the implementation of Base62.decode directly but then I figured it would be an issue if anyone is storing the decode method in a variable ( `var b62decode = Base.decode;` ) , hence why the swap is done on the `decodeImplementation` variable.

The implementation of the decode method for custom charset has also been slightly optimized.

This mostly stems from my work on [ya-base62](https://github.com/kchapelier/ya-base62) and the benchmarking I did on it. That module has slightly different design goals (handling structured strings) and I figured out I might as well contribute to the most depended upon base62 module as it will probably be more beneficial to the community.

**Before modifications**

| Operations | Results | Elapsed time |
| ----------- | ------- | ------------- |
| decoding with default charset (1000000x) | correct | 2166.29 ms |
| encoding with default charset (1000000x) | correct | 58.42 ms |
| decoding with custom charset (1000000x) | correct | 2873.36 ms |
| encoding with custom charset (1000000x) | correct | 57.60 ms |

**After modifications**

| Operations | Results | Elapsed time |
| ----------- | ------- | ------------- |
| decoding with default charset (1000000x) | correct | 81.88 ms |
| encoding with default charset (1000000x) | correct | 58.63 ms |
| decoding with custom charset (1000000x) | correct | 1727.05 ms |
| encoding with custom charset (1000000x) | correct | 55.26 ms |

The benchmark code is included in the PR (it's excluded from `.codeclimate.yml`).

A few minor tests were added just to make sure unwanted changes are not introduced.