### PR TITLE
Add support for arbitrary-length charsets

### DIFF
--- a/lib/ascii.js
+++ b/lib/ascii.js
@@ -22,11 +22,11 @@ exports.decode = function decode(str) {
         i, char;
     for (i = 0; i < length; i++) {
         char = str.charCodeAt(i);
-        if (char < 58) {
+        if (char < 58) { // 0-9
             char = char - 48;
-        } else if (char < 91) {
+        } else if (char < 91) { // A-Z
             char = char - 29;
-        } else {
+        } else { // a-z
             char = char - 87;
         }
         res += char * Math.pow(62, length - i - 1);

--- a/lib/custom.js
+++ b/lib/custom.js
@@ -7,10 +7,11 @@ exports.encode = function encode(int, charset) {
         return byCode[0];
     }
 
-    var res = "";
+    var res = "",
+        max = charset.length;
     while (int > 0) {
-        res = byCode[int % 62] + res;
-        int = Math.floor(int / 62);
+        res = byCode[int % max] + res;
+        int = Math.floor(int / max);
     }
     return res;
 };
@@ -31,11 +32,12 @@ exports.decode = function decode(str, charset) {
 exports.indexCharset = function indexCharset(str) {
     var byCode = {},
         byChar = {},
+        length = str.length,
         i, char;
-    for (i = 0; i < str.length; i++) {
+    for (i = 0; i < length; i++) {
         char = str[i];
         byCode[i] = char;
         byChar[char] = i;
     }
-    return { byCode: byCode, byChar: byChar };
+    return { byCode: byCode, byChar: byChar, length: length };
 };

--- a/test/test_ascii.js
+++ b/test/test_ascii.js
@@ -13,6 +13,7 @@ describe("Base62 codec (ASCII)", function() {
         assertSame(encode(0), "0");
         assertSame(encode(7), "7");
         assertSame(encode(16), "g");
+        assertSame(encode(61), "Z");
         assertSame(encode(65), "13");
         assertSame(encode(999), "g7");
         assertSame(encode(9999), "2Bh");
@@ -25,6 +26,7 @@ describe("Base62 codec (ASCII)", function() {
         assertSame(decode("0"), 0);
         assertSame(decode("7"), 7);
         assertSame(decode("g"), 16);
+        assertSame(decode("Z"), 61);
         assertSame(decode("13"), 65);
         assertSame(decode("0013"), 65); // ignore leading zeros
         assertSame(decode("g7"), 999);

--- a/test/test_custom.js
+++ b/test/test_custom.js
@@ -30,3 +30,17 @@ describe("Base62 codec (custom character set)", function() {
         assertSame(decode("~~~", charset), 238327);
     });
 });
+
+describe("arbitrary-length charsets (e.g. Base66)", function() {
+    var ascii = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    var charset = ascii + "äöüß";
+    charset = base62.indexCharset(charset);
+
+    it("should encode numbers", function() {
+        assertSame(encode(65, charset), "ß");
+    });
+
+    it("should decode strings", function() {
+        assertSame(decode("ß", charset), 65);
+    });
+});


### PR DESCRIPTION
From the commit message:

> as pointed out by @tillsc, there's no technical reason not to support
> this - though naming and documentation complicate things a little

I figured it'd make sense to decide whether we want this or not before releasing v2.0 (cf. #70).

I realize technical feasibility alone is not a good reason, but this does seem potentially useful - though I wouldn't bother advertising it at this point.