### PR TITLE
Add BigInt support for encode and decode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,6 +42,13 @@ base62.decode("g7"); // 999
 
 This uses the default **ASCII character set** for encoding/decoding.
 
+Both `encode` and `decode` support BigInt for values beyond `Number.MAX_SAFE_INTEGER`:
+
+```javascript
+base62.encode(9007199254740993n);                    // "FfGNdXsE9"
+base62.decode("FfGNdXsE9", { bigint: true });        // 9007199254740993n
+```
+
 It's also possible to define a **custom character set** instead:
 
 ```javascript

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
 declare namespace base62 {
     export function setCharacterSet(characters: string): void
-    export function encode(number: number): string
+    export function encode(number: number | bigint): string
     export function decode(string: string): number
+    export function decode(string: string, options: { bigint: true }): bigint
 }
 
 export = base62

--- a/lib/ascii.js
+++ b/lib/ascii.js
@@ -4,6 +4,18 @@ var CHARSET = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".s
 
 // NB: does not validate input
 exports.encode = function encode(int) {
+    if (typeof int === "bigint") {
+        if (int === 0n) {
+            return CHARSET[0];
+        }
+        var res = "";
+        while (int > 0n) {
+            res = CHARSET[Number(int % 62n)] + res;
+            int = int / 62n;
+        }
+        return res;
+    }
+
     if (int === 0) {
         return CHARSET[0];
     }
@@ -16,10 +28,28 @@ exports.encode = function encode(int) {
     return res;
 };
 
-exports.decode = function decode(str) {
-    var res = 0,
-        length = str.length,
-        i, char;
+exports.decode = function decode(str, options) {
+    var useBigInt = options && options.bigint;
+    var length = str.length;
+    var i, char;
+
+    if (useBigInt) {
+        var res = 0n;
+        for (i = 0; i < length; i++) {
+            char = str.charCodeAt(i);
+            if (char < 58) {
+                char = char - 48;
+            } else if (char < 91) {
+                char = char - 29;
+            } else {
+                char = char - 87;
+            }
+            res += BigInt(char) * 62n ** BigInt(length - i - 1);
+        }
+        return res;
+    }
+
+    var res = 0;
     for (i = 0; i < length; i++) {
         char = str.charCodeAt(i);
         if (char < 58) { // 0-9

--- a/lib/custom.js
+++ b/lib/custom.js
@@ -2,7 +2,21 @@
 
 // NB: does not validate input
 exports.encode = function encode(int, charset) {
-    let byCode = charset.byCode;
+    var byCode = charset.byCode;
+
+    if (typeof int === "bigint") {
+        if (int === 0n) {
+            return byCode[0];
+        }
+        var res = "",
+            max = BigInt(charset.length);
+        while (int > 0n) {
+            res = byCode[Number(int % max)] + res;
+            int = int / max;
+        }
+        return res;
+    }
+
     if (int === 0) {
         return byCode[0];
     }
@@ -16,12 +30,23 @@ exports.encode = function encode(int, charset) {
     return res;
 };
 
-exports.decode = function decode(str, charset) {
+exports.decode = function decode(str, charset, options) {
     var byChar = charset.byChar,
-        res = 0,
         length = str.length,
         max = charset.length,
         i, char;
+
+    if (options && options.bigint) {
+        var res = 0n,
+            bigMax = BigInt(max);
+        for (i = 0; i < length; i++) {
+            char = str[i];
+            res += BigInt(byChar[char]) * bigMax ** BigInt(length - i - 1);
+        }
+        return res;
+    }
+
+    var res = 0;
     for (i = 0; i < length; i++) {
         char = str[i];
         res += byChar[char] * Math.pow(max, (length - i - 1));

--- a/lib/legacy.js
+++ b/lib/legacy.js
@@ -24,7 +24,7 @@ var Base62 = { // NB: mutable singleton
 
         charset = base62custom.indexCharset(charset);
         Base62.encode = function(value) { return base62custom.encode(value, charset) };
-        Base62.decode = function(value) { return base62custom.decode(value, charset) };
+        Base62.decode = function(value, options) { return base62custom.decode(value, charset, options) };
     }
 };
 

--- a/test/test_ascii.js
+++ b/test/test_ascii.js
@@ -35,4 +35,25 @@ describe("Base62 codec (ASCII)", function() {
         assertSame(decode("2Q3rKTOF"), 10000000000001);
         assertSame(decode("2Q3rKTOH"), 10000000000003);
     });
+
+    it("should encode BigInt values", function() {
+        assertSame(encode(0n), "0");
+        assertSame(encode(999n), "g7");
+        assertSame(encode(238327n), "ZZZ");
+        assertSame(encode(9007199254740993n), "FfGNdXsE9");
+    });
+
+    it("should decode to BigInt when requested", function() {
+        assertSame(decode("0", { bigint: true }), 0n);
+        assertSame(decode("g7", { bigint: true }), 999n);
+        assertSame(decode("ZZZ", { bigint: true }), 238327n);
+        assertSame(decode("FfGNdXsE9", { bigint: true }), 9007199254740993n);
+    });
+
+    it("should roundtrip BigInt values beyond Number.MAX_SAFE_INTEGER", function() {
+        var big = 123456789012345678901234567890n;
+        var encoded = encode(big);
+        var decoded = decode(encoded, { bigint: true });
+        assertSame(decoded, big);
+    });
 });

--- a/test/test_custom.js
+++ b/test/test_custom.js
@@ -29,6 +29,25 @@ describe("Base62 codec (custom character set)", function() {
         assertSame(decode("7bH", charset), 9999);
         assertSame(decode("~~~", charset), 238327);
     });
+
+    it("should encode BigInt values", function() {
+        assertSame(encode(0n, charset), "9");
+        assertSame(encode(999n, charset), "G2");
+        assertSame(encode(238327n, charset), "~~~");
+    });
+
+    it("should decode to BigInt when requested", function() {
+        assertSame(decode("9", charset, { bigint: true }), 0n);
+        assertSame(decode("G2", charset, { bigint: true }), 999n);
+        assertSame(decode("~~~", charset, { bigint: true }), 238327n);
+    });
+
+    it("should roundtrip BigInt values beyond Number.MAX_SAFE_INTEGER", function() {
+        var big = 123456789012345678901234567890n;
+        var encoded = encode(big, charset);
+        var decoded = decode(encoded, charset, { bigint: true });
+        assertSame(decoded, big);
+    });
 });
 
 describe("arbitrary-length charsets (e.g. Base66)", function() {

--- a/test/test_legacy.js
+++ b/test/test_legacy.js
@@ -26,6 +26,19 @@ describe("decode", function() {
         assert.equal(Base62.decode("2Q3rKTOF"), 10000000000001);
         assert.equal(Base62.decode("2Q3rKTOH"), 10000000000003);
     });
+
+    it("should decode to BigInt when requested", function() {
+        assert.equal(Base62.decode('g7', { bigint: true }), 999n);
+        assert.equal(Base62.decode("FfGNdXsE9", { bigint: true }), 9007199254740993n);
+    });
+});
+
+describe("BigInt encode", function() {
+    it("should encode BigInt values", function() {
+        assert.equal(Base62.encode(0n), '0');
+        assert.equal(Base62.encode(999n), 'g7');
+        assert.equal(Base62.encode(9007199254740993n), 'FfGNdXsE9');
+    });
 });
 
 describe("setCharacterSequence", function(){


### PR DESCRIPTION
`encode()` now accepts BigInt values directly. `decode()` accepts an optional `{ bigint: true }` option to return a BigInt, allowing lossless handling of values beyond `Number.MAX_SAFE_INTEGER`. TypeScript types and readme updated.

Closes #78