### PR TITLE
Simplify readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,17 +4,15 @@
 [![npm downloads](https://img.shields.io/npm/dm/base62.svg)](https://www.npmjs.com/package/base62)
 [![license](https://img.shields.io/npm/l/base62.svg)](https://github.com/base62/base62.js/blob/master/LICENSE)
 
-A JavaScript Base62 encode/decoder
-
-## What is Base62 encoding?
+A JavaScript Base62 encode/decoder.
 
 Base62 encoding converts numbers to ASCII strings (0-9, a-z and A-Z) and vice
 versa, which typically results in comparatively short strings. Such identifiers
-also tend to more readily identifiable by humans.
+also tend to be more readily identifiable by humans.
 
-* `999` ≙ `"g7"`
-* `9999` ≙ `"2Bh"`
-* `238327` ≙ `"ZZZ"`
+* `999` -> `"g7"`
+* `9999` -> `"2Bh"`
+* `238327` -> `"ZZZ"`
 
 
 ## Installation
@@ -23,108 +21,49 @@ also tend to more readily identifiable by humans.
 npm install base62
 ```
 
-alternatively using Yarn:
-
-```shell
-yarn add base62
-```
-
 
 ## Usage
 
-For backwards compatibility, Base62.js exposes v1.x's API by default – see
-[Legacy API](#legacy-api) below. For efficiency, v2.x's modernized API allows
-selectively importing individual modules instead:
-
 ```javascript
-var base62 = require("base62/lib/ascii");
+var base62 = require("base62");
 
 base62.encode(999);  // "g7"
 base62.decode("g7"); // 999
 ```
-
-This uses the default **ASCII character set** for encoding/decoding.
 
 Both `encode` and `decode` support BigInt for values beyond `Number.MAX_SAFE_INTEGER`:
 
 ```javascript
-base62.encode(9007199254740993n);                    // "FfGNdXsE9"
-base62.decode("FfGNdXsE9", { bigint: true });        // 9007199254740993n
+base62.encode(9007199254740993n);                // "FfGNdXsE9"
+base62.decode("FfGNdXsE9", { bigint: true });    // 9007199254740993n
 ```
 
-It's also possible to define a **custom character set** instead:
-
-```javascript
-var base62 = require("base62/lib/custom");
-
-var charset = "~9876543210ABCDEFGHIJKLMNOPQRSTU$#@%!abcdefghijklmnopqrstuvw-=";
-charset = base62.indexCharset(charset);
-
-base62.encode(999, charset);  // "F3"
-base62.decode("F3", charset); // 999
-```
-
-Note that `indexCharset` typically expects the respective string to contain
-exactly 62 unique character, but does not validate this for efficieny. In fact,
-it's also possible to use characters sets with more than 62 characters in order
-to achieve shorter identifiers for large numbers.
-
-
-### Legacy API
-
-Base62.js v1.x's API is maintained for backwards compatibility.
+You can also use a custom character set:
 
 ```javascript
 var base62 = require("base62");
 
-base62.encode(999);  // "g7"
-base62.decode("g7"); // 999
-```
-
-This uses the default **ASCII character set** for encoding/decoding.
-
-It's also possible to define a **custom character set** instead:
-
-```javascript
-var base62 = require("base62");
-
-var charset = "~9876543210ABCDEFGHIJKLMNOPQRSTU$#@%!abcdefghijklmnopqrstuvw-=";
-base62.setCharacterSet(charset);
+base62.setCharacterSet("~9876543210ABCDEFGHIJKLMNOPQRSTU$#@%!abcdefghijklmnopqrstuvw-=");
 
 base62.encode(999);  // "F3"
 base62.decode("F3"); // 999
 ```
 
-`setCharacterSet` ensures that the respective string contains exactly 62 unique
-characters.
+`setCharacterSet` expects a string containing exactly 62 unique characters.
 
 
 ## Development
 
 Source code is hosted on [GitHub](http://github.com/base62/base62.js).
 Please report issues or feature requests in
-[GitHub Issues](http://github.com/base62/base62.js.issues).
-
-
-### Note on Patches/Pull Requests
+[GitHub Issues](https://github.com/base62/base62.js/issues).
 
  * Fork the project.
  * Make your feature addition or bug fix.
- * Add tests for it. This is important so I don't break it in a future version
-   unintentionally.
- * Send me a pull request. Bonus points for topic branches.
+ * Add tests for it.
+ * Send a pull request.
 
 
-### Release Process for Maintainers
+## License
 
- * Update the version number in `package.json`.
- * Commit this change with the respective version number as commit message
-   (e.g. "1.2.3").
- * Create an annotated tag, using the prefixed version number (e.g.
-   `git tag -am "1.2.3" v1.2.3`).
- * Publish the new version: `git push --tags origin master` and `npm publish`.
-
-
-## Copyright
-
-Copyright (c) 2024 Andrew Nesbitt. See [LICENSE](https://github.com/base62/base62.js/blob/master/LICENSE) for details.
+MIT. Copyright (c) 2026 Andrew Nesbitt. See [LICENSE](https://github.com/base62/base62.js/blob/master/LICENSE) for details.


### PR DESCRIPTION
Drop the v1/v2 API distinction since they're the same thing. Document one API with the standard require path. Remove the yarn install alternative, maintainer release process, and fix some typos.